### PR TITLE
change shebang invocation for guile to a more portable `env sh`

### DIFF
--- a/jaro
+++ b/jaro
@@ -1,5 +1,5 @@
-#!/bin/guile \
--e main -s
+#!/usr/bin/env sh
+exec guile --no-auto-compile -e main -s "$0" "$@"
 !#
 
 (use-modules (ice-9 regex)

--- a/jaro
+++ b/jaro
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-exec guile --no-auto-compile -e main -s "$0" "$@"
+exec guile -e main -s "$0" "$@"
 !#
 
 (use-modules (ice-9 regex)


### PR DESCRIPTION
UNIX systems can vary quite often where a binary might be with directory structures or the case of compiling something yourself. Example on my Fedora system /bin/guile doesn't even exist but /bin/guile2.2 does, but even further I'm using a newer Guile 3.0.5 which I've compiled myself that is located at /usr/local/bin/guile

Further tedium ensues with functional package management systems such as Guix or Nix, so I believe this to be the simplest and most portable approach, hopefully it helps.

For reference: https://www.gnu.org/software/guile/manual/html_node/Scripting-Examples.html